### PR TITLE
Fix coroutine AttributeError by awaiting chat.completions.create in run_async

### DIFF
--- a/research_agent/inno/core.py
+++ b/research_agent/inno/core.py
@@ -472,7 +472,7 @@ class MetaChain:
 
             if tools and create_params['model'].startswith("gpt"):
                 create_params["parallel_tool_calls"] = agent.parallel_tool_calls
-            completion_response = acompletion(**create_params)
+            completion_response = await acompletion(**create_params)
         elif create_model in NOT_USE_FN_CALL:
             assert agent.tool_choice == "required", f"Non-function calling mode MUST use tool_choice = 'required' rather than {agent.tool_choice}"
             last_content = messages[-1]["content"]


### PR DESCRIPTION
## Description
This PR fixes an AttributeError: 'coroutine' object has no attribute 'choices' by ensuring that the asynchronous OpenAI API call is properly awaited in the run_async method.
This also addresses issue https://github.com/HKUDS/AI-Researcher/issues/25.

## Root Cause
- In inno/core.py, the run_async method was calling the OpenAI API without using await, so the result stored in completion was still a coroutine rather than an actual response object.
- As a result, when the code attempted to access completion.choices, it raised AttributeError: 'coroutine' object has no attribute 'choices'.

## Solution
- Add await to the OpenAI API call so that completion receives the actual response object instead of an un-awaited coroutine.

