### PR TITLE
docs: fix community QR image URL and add CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to AI-Researcher
+
+Thank you for your interest in contributing to AI-Researcher! We welcome contributions from researchers, developers, and AI enthusiasts.
+
+## How to contribute
+
+1. **Fork** the repository on GitHub.
+2. **Clone** your fork locally:
+   ```bash
+   git clone https://github.com/<your-username>/AI-Researcher.git
+   cd AI-Researcher
+   ```
+3. **Create a branch** for your change:
+   ```bash
+   git checkout -b fix/your-topic
+   ```
+4. **Make your changes** — bug fixes, documentation improvements, and small enhancements are great first contributions.
+5. **Commit** with a clear message describing what you changed and why.
+6. **Push** to your fork and open a **Pull Request** against `HKUDS/AI-Researcher` `main`.
+
+## Good first contributions
+
+- Fix typos or broken links in the README or docs
+- Improve installation or setup instructions
+- Report or fix bugs listed in [Issues](https://github.com/HKUDS/AI-Researcher/issues)
+
+## Community
+
+- [Slack](https://join.slack.com/t/ai-researchergroup/shared_invite/zt-30y5a070k-C0ajQt1zmVczFnfGkIicvA)
+- [Discord](https://discord.gg/zBNYTk5q2g)
+- [GitHub Issues](https://github.com/HKUDS/AI-Researcher/issues)
+
+Before starting large features, please open an issue to discuss your idea with the maintainers.

--- a/Communication.md
+++ b/Communication.md
@@ -2,5 +2,5 @@ We provide QR codes for joining the HKUDS discussion groups on WeChat and Feishu
 
 You can join by scanning the QR codes below:
 
-<img src="https://github.com/HKUDS/.github/blob/main/profile/QR.png" alt="WeChat QR Code" width="400"/>
+<img src="https://raw.githubusercontent.com/HKUDS/.github/main/profile/QR.png" alt="HKUDS WeChat and Feishu group QR codes" width="400"/>
 


### PR DESCRIPTION
The Communication.md QR code used a GitHub blob URL that does not render in markdown img tags. Switch to raw.githubusercontent.com. Add CONTRIBUTING.md with fork-and-PR workflow for new contributors.